### PR TITLE
Comment out undefined PRETTYCONShier call in semfuns.nlp

### DIFF
--- a/spec/semfuns.nlp
+++ b/spec/semfuns.nlp
@@ -302,7 +302,11 @@ if (L("nsenses"))	# 02/08/11 AM.
 if (L("matchcons") = pnvar(L("v"),"MATCHCONS"))		# 03/17/14 AM.
   {
   pnreplaceval(L("vg"),"MATCHCONS",L("matchcons"));	# 03/17/14 AM.
-  PRETTYCONShier(L("matchcons"),G("mhdump"));
+  # PRETTYCONShier(L("matchcons"),G("mhdump"));	# Undefined function.
+  # The interpreter tolerated this (the if-condition is rarely true,
+  # so the call rarely fired), but the C++ compile path can't resolve
+  # the symbol at link time and the build fails. Commented out pending
+  # a decision on whether to define the function or drop the block.
   }
 }
 


### PR DESCRIPTION
## Summary

`semfuns.nlp` line 305 calls `PRETTYCONShier(...)`, a function that is **not defined anywhere** in this analyzer or in engine builtins. Closest defined names: `prettynodes`, `prettystrs`, `prettypns`. Looks like an unfinished 2014-era debug-dump helper.

## Why this is showing up now

The interpreter has tolerated this for years because the `if (L("matchcons") = pnvar(L("v"),"MATCHCONS"))` condition is rarely true at runtime — the call site almost never fires, so a runtime "function not found" never surfaced.

The new cloud-compile path runs `nlp.exe -COMPILE` → cmake → MSVC, which has to resolve **every** referenced symbol at link time, including ones in dead branches. The build fails with:

error run/pass6.cpp: 'PRETTYCONShier': identifier not found
error run/pass6.cpp: 'Arun::stmt': ambiguous call to overloaded function


(The second error is a cascade: once the compiler can't determine `PRETTYCONShier`'s return type, the surrounding `Arun::stmt(PRETTYCONShier(...))` overload resolution falls apart.)

## Change

Comments out the offending line and leaves an inline note explaining the situation. Doesn't try to guess what `PRETTYCONShier` was supposed to do — that's a separate decision (define the helper, or drop the whole if-block).
