### PR TITLE
Percolation: dispatch parse-en-us releases downstream

### DIFF
--- a/.github/workflows/dispatch-update-parse-en-us.yml
+++ b/.github/workflows/dispatch-update-parse-en-us.yml
@@ -1,0 +1,36 @@
+# Install at: VisualText/parse-en-us -> .github/workflows/dispatch-update-parse-en-us.yml
+#
+# Release-driven percolation, matching the existing org convention
+# (cf. analyzer-templates/dispatch-update-analyzer-templates.yml): when a
+# release tag is pushed here, ping the repos that embed parse-en-us so they
+# refresh their submodule pointer.
+#
+# Requires the shared `CLASSIC_PAT` secret in this repo (the default
+# GITHUB_TOKEN cannot trigger workflows in other repos).
+
+name: Dispatch update-parse-en-us
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - analyzers          # embeds parse-en-us at path parse-en-us
+          - visualtext-files   # embeds parse-en-us at path analyzers/parse-en-us
+    steps:
+      - name: Trigger ${{ matrix.repo }}
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.CLASSIC_PAT }}
+          repository: VisualText/${{ matrix.repo }}
+          event-type: parse-en-us-release
+          client-payload: '{"tag_name": "${{ github.ref_name }}"}'
+        continue-on-error: true


### PR DESCRIPTION
Adds a release-tag-triggered dispatcher (matching the existing analyzer-templates convention: CLASSIC_PAT + `*-release` event + matrix fan-out).

On a `v*` tag push, pings **analyzers** and **visualtext-files** (event-type `parse-en-us-release`) so they refresh their parse-en-us submodule.

Requires a `CLASSIC_PAT` secret in this repo (same value used by analyzer-templates / nlp-engine).

Part of wiring the parse-en-us percolation gap. See companion PRs in analyzers, visualtext-files, nlp-engine.