### PR TITLE
docs: link cross-repo release percolation doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ It was developed over the period of many years in a bottom up manner. It uses th
 ## Starting Template
 
 It is recommended that if full parsing of English is needed in an analyzer, to start with this. It has been used as the basis for numerous text analyzers throughout the years.
+
+## Cross-repo release automation
+
+This repo participates in the VisualText cross-repo release "percolation"
+system: submodule bumps flow downstream automatically via `repository_dispatch`.
+See **[nlp-engine/docs/PERCOLATION.md](https://github.com/VisualText/nlp-engine/blob/master/docs/PERCOLATION.md)** for the full map.


### PR DESCRIPTION
Adds a one-line README pointer to the central percolation doc (`nlp-engine/docs/PERCOLATION.md`). Docs only.